### PR TITLE
Improve ContractResolver performance

### DIFF
--- a/src/RuntimeContracts.Analyzer.CodeFixes/RoslynUtilities/SyntaxTreeUtilities.cs
+++ b/src/RuntimeContracts.Analyzer.CodeFixes/RoslynUtilities/SyntaxTreeUtilities.cs
@@ -13,8 +13,8 @@ namespace RuntimeContracts.Analyzer.Utilities
         public static SyntaxNode AddOrReplaceContractNamespaceUsings(SyntaxNode root)
         {
             return ReplaceNamespaceUsings(root,
-                originalNamespace: "SystemDiagnostics.Contracts",
-                newNamespace: "SystemDiagnostics.ContractsLight");
+                originalNamespace: "System.Diagnostics.Contracts",
+                newNamespace: "System.Diagnostics.ContractsLight");
         }
 
         public static SyntaxNode AddNamespaceUsingsIfNeeded(SyntaxNode root, string namespaceName)

--- a/src/RuntimeContracts.Analyzer.CodeFixes/UseFluentContractsCodeFixProvider.cs
+++ b/src/RuntimeContracts.Analyzer.CodeFixes/UseFluentContractsCodeFixProvider.cs
@@ -63,7 +63,7 @@ namespace RuntimeContracts.Analyzer
             foreach (var invocationExpression in invocationExpressions)
             {
                 var operation = (IInvocationOperation)semanticModel.GetOperation(invocationExpression);
-                var contractResolver = new ContractResolver(semanticModel);
+                var contractResolver = new ContractResolver(semanticModel.Compilation);
 
                 if (contractResolver.GetContractInvocation(operation.TargetMethod, out var contractMethod))
                 {

--- a/src/RuntimeContracts.Analyzer.Test/DoNotUseStandardContractAnalyzerTest.cs
+++ b/src/RuntimeContracts.Analyzer.Test/DoNotUseStandardContractAnalyzerTest.cs
@@ -9,7 +9,7 @@ namespace RuntimeContracts.Analyzer.Test
     [TestClass]
     public class DoNotUseStandardContractAnalyzerTest
     {
-        //[TestMethod]
+        [TestMethod]
         public async Task FailsOnContractRequires()
         {
             var test = @"using System.Diagnostics.Contracts;
@@ -28,10 +28,11 @@ namespace RuntimeContracts.Analyzer.Test
             await new VerifyCS.Test
             {
                 TestState = { Sources = { test } },
+                FixedState = { Sources = { test.Replace("System.Diagnostics.Contracts", "System.Diagnostics.ContractsLight") } },
             }.WithoutGeneratedCodeVerification().RunAsync();
         }
 
-        //[TestMethod]
+        [TestMethod]
         public async Task FixUsingOnTopLevel()
         {
             var test = @"using System;
@@ -55,7 +56,7 @@ using System.Diagnostics.Contracts;
             }.WithoutGeneratedCodeVerification().RunAsync();
         }
 
-        //[TestMethod]
+        [TestMethod]
         public async Task FixUsingInsideNamespace()
         {
             var test = @"using System;
@@ -79,7 +80,7 @@ using System.Diagnostics.Contracts;
             }.WithoutGeneratedCodeVerification().RunAsync();
         }
 
-        //[TestMethod]
+        [TestMethod]
         public async Task FixUsingInsideSecondNamespace()
         {
             var test = @"using System;

--- a/src/RuntimeContracts.Analyzer/Analyzers/DoNotUseStandardContractAnalyzer.cs
+++ b/src/RuntimeContracts.Analyzer/Analyzers/DoNotUseStandardContractAnalyzer.cs
@@ -1,8 +1,7 @@
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
 using RuntimeContracts.Analyzer.Core;
 #nullable enable
 
@@ -31,17 +30,17 @@ namespace RuntimeContracts.Analyzer
             {
                 var resolver = new ContractResolver(context.Compilation);
 
-                context.RegisterSyntaxNodeAction(context => AnalyzeSyntax(context, resolver), SyntaxKind.InvocationExpression);
+                context.RegisterOperationAction(context => AnalyzeInvocation(context, resolver), OperationKind.Invocation);
             });
         }
 
-        private static void AnalyzeSyntax(SyntaxNodeAnalysisContext context, ContractResolver resolver)
+        private static void AnalyzeInvocation(OperationAnalysisContext context, ContractResolver resolver)
         {
-            var invocation = (InvocationExpressionSyntax)context.Node;
+            var invocation = (IInvocationOperation)context.Operation;
 
-            if (resolver.IsStandardContractInvocation(invocation, context.SemanticModel))
+            if (resolver.IsStandardContractInvocation(invocation.TargetMethod))
             {
-                var diagnostic = Diagnostic.Create(Rule, invocation.GetLocation());
+                var diagnostic = Diagnostic.Create(Rule, invocation.Syntax.GetLocation());
 
                 context.ReportDiagnostic(diagnostic);
             }

--- a/src/RuntimeContracts.Analyzer/Analyzers/FluentAssertionResultIsNotObservedAnalyzer.cs
+++ b/src/RuntimeContracts.Analyzer/Analyzers/FluentAssertionResultIsNotObservedAnalyzer.cs
@@ -40,13 +40,17 @@ namespace RuntimeContracts.Analyzer
             context.EnableConcurrentExecution();
             context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
 
-            context.RegisterOperationAction(AnalyzeInvocationOperation, OperationKind.Invocation);
+            context.RegisterCompilationStartAction(context =>
+            {
+                var resolver = new ContractResolver(context.Compilation);
+
+                context.RegisterOperationAction(context => AnalyzeInvocationOperation(context, resolver), OperationKind.Invocation);
+            });
         }
 
-        private void AnalyzeInvocationOperation(OperationAnalysisContext context)
+        private void AnalyzeInvocationOperation(OperationAnalysisContext context, ContractResolver resolver)
         {
             var invocation = (IInvocationOperation)context.Operation;
-            var resolver = new ContractResolver(invocation.SemanticModel);
 
             // Looking for contract methods based  on 'RuntimeContracts' package.
             if (resolver.IsFluentContractInvocation(invocation.TargetMethod))

--- a/src/RuntimeContracts.Analyzer/Analyzers/UseFluentContractsAnalyzer.cs
+++ b/src/RuntimeContracts.Analyzer/Analyzers/UseFluentContractsAnalyzer.cs
@@ -35,14 +35,17 @@ namespace RuntimeContracts.Analyzer
             context.EnableConcurrentExecution();
             context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
 
-            context.RegisterOperationAction(AnalyzeOperation, OperationKind.Invocation);
+            context.RegisterCompilationStartAction(context =>
+            {
+                var resolver = new ContractResolver(context.Compilation);
+
+                context.RegisterOperationAction(context => AnalyzeOperation(context, resolver), OperationKind.Invocation);
+            });
         }
 
-        private void AnalyzeOperation(OperationAnalysisContext context)
+        private void AnalyzeOperation(OperationAnalysisContext context, ContractResolver resolver)
         {
             var invocation = (IInvocationOperation)context.Operation;
-
-            var resolver = new ContractResolver(context.Operation.SemanticModel);
 
             var contracts = AllAsserts | AllRequires | Assume | Ensures | EnsuresOnThrow;
             

--- a/src/RuntimeContracts.Analyzer/Core/ContractResolver.cs
+++ b/src/RuntimeContracts.Analyzer/Core/ContractResolver.cs
@@ -1,6 +1,4 @@
 ﻿using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using RuntimeContracts.Analyzer.Utilities;
 
 #nullable enable
 
@@ -31,30 +29,6 @@ namespace RuntimeContracts.Analyzer.Core
 
         /// <summary>
         /// Returns true if a given <paramref name="invocationExpression"/> invokes member
-        /// of a <see cref="System.Diagnostics.Contracts.Contract"/> class.
-        /// </summary>
-        public bool IsStandardContractInvocation(
-            InvocationExpressionSyntax invocationExpression,
-            SemanticModel semanticModel,
-            ContractMethodNames allowedMethodNames = ContractMethodNames.All)
-        {
-            return IsContractInvocation(invocationExpression, semanticModel, allowedMethodNames, _standardContractTypeSymbol);
-        }
-
-        /// <summary>
-        /// Returns true if a given <paramref name="invocationExpression"/> invokes member
-        /// of a System.Diagnostics.ContractsLight.Contract class.
-        /// </summary>
-        public bool IsContractInvocation(
-            InvocationExpressionSyntax invocationExpression,
-            SemanticModel semanticModel,
-            ContractMethodNames allowedMethodNames = ContractMethodNames.All)
-        {
-            return IsContractInvocation(invocationExpression, semanticModel, allowedMethodNames, _runtimeContractTypeSymbol);
-        }
-
-        /// <summary>
-        /// Returns true if a given <paramref name="invocationExpression"/> invokes member
         /// of a System.Diagnostics.ContractsLight.Contract class.
         /// </summary>
         public bool GetContractInvocation(IMethodSymbol invokedMethod, out ContractMethodNames contract)
@@ -67,18 +41,6 @@ namespace RuntimeContracts.Analyzer.Core
 
             contract = ParseContractMethodName(invokedMethod.Name);
             return true;
-        }
-
-        /// <summary>
-        /// Returns true if a given <paramref name="invocationExpression"/> invokes member
-        /// of a System.Diagnostics.FluentContracts.Contract class.
-        /// </summary>
-        public bool IsFluentContractInvocation(
-            InvocationExpressionSyntax invocationExpression,
-            SemanticModel semanticModel,
-            ContractMethodNames allowedMethodNames = ContractMethodNames.AllFluentContracts)
-        {
-            return IsContractInvocation(invocationExpression, semanticModel, allowedMethodNames, _runtimeContractTypeSymbol);
         }
 
         /// <summary>
@@ -127,35 +89,6 @@ namespace RuntimeContracts.Analyzer.Core
 
         public static ContractMethodNames ParseContractMethodName(string? methodName)
             => ContractMethodNamesExtensions.ParseContractMethodName(methodName);
-
-        private bool IsContractInvocation(
-            InvocationExpressionSyntax invocationExpression,
-            SemanticModel semanticModel,
-            ContractMethodNames allowedMethodNames,
-            INamedTypeSymbol contractTypeSymbol)
-        {
-            MemberAccessExpressionSyntax? memberAccess =
-                invocationExpression
-                .Expression.As(x => x as MemberAccessExpressionSyntax);
-
-            if ((ParseContractMethodName(memberAccess?.Name.Identifier.Text) & allowedMethodNames) == ContractMethodNames.None)
-            {
-                return false;
-            }
-
-            var memberSymbol =
-                memberAccess
-                ?.As(x => semanticModel.GetSymbolInfo(x).Symbol as IMethodSymbol);
-
-            // TODO: ToMetadataFullName() on every call is probably somewhat expensive
-            if (memberSymbol == null || !memberSymbol.ContainingType.Equals(contractTypeSymbol))
-            {
-                // This is not Contract.
-                return false;
-            }
-
-            return true;
-        }
 
         private bool IsContractInvocation(
             IMethodSymbol? memberSymbol,


### PR DESCRIPTION
* Only create one `ContractResolver` instance per compilation
* Use IOperation APIs where symbols will be analyzed