### PR TITLE
Target .NET Standard 2.0 in the library.

### DIFF
--- a/src/RuntimeContracts/RuntimeContracts.csproj
+++ b/src/RuntimeContracts/RuntimeContracts.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <RuntimeContractsVersion>0.5.0.0</RuntimeContractsVersion>
-        <TargetFramework>netstandard1.1</TargetFramework>
+        <TargetFramework>netstandard2.0</TargetFramework>
         <RootNamespace>System.Diagnostics.ContractsLight</RootNamespace>
         <nullable>enable</nullable>
     </PropertyGroup>


### PR DESCRIPTION
This PR updates `RuntimeContracts.csproj` to target .NET Standard 2.0 instead of 1.1, fixing [build warnings added in .NET 9 SDK](https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/9.0/netstandard-warning), and dramatically reducing the amount of transitive dependencies when using this package.